### PR TITLE
Add support for API keys

### DIFF
--- a/src/edie/api.py
+++ b/src/edie/api.py
@@ -4,19 +4,29 @@ from urllib.parse import urlencode
 class ApiClient(object):
     """A client for the ELEXIS API"""
 
-    def __init__(self, endpoint):
+    def __init__(self, endpoint, api_key):
         if not endpoint.endswith("/"):
             self.endpoint = endpoint + "/"
         else:
             self.endpoint = endpoint
+        self.api_key = api_key
 
+    def __get_header(self):
+        if self.api_key:
+            return {"X-API-KEY": self.api_key}
+        else:
+            return {}
 
     def dictionaries(self):
-        return requests.get(self.endpoint + "dictionaries").json()
+        headers = self.__get_header()
+        return requests.get(self.endpoint + "dictionaries",
+                headers=headers).json()
 
     
     def about(self, dictionary):
-        return requests.get(self.endpoint + "about/" + dictionary).json()
+        headers = self.__get_header()
+        return requests.get(self.endpoint + "about/" + dictionary,
+                headers=headers).json()
 
 
     def list(self, dictionary, limit=None, offset=None):
@@ -30,10 +40,12 @@ class ApiClient(object):
             url = f"{self.endpoint}list/{dictionary}?{qstr}"
         else:
             url = f"{self.endpoint}list/{dictionary}"
-        return requests.get(url).json()
+        headers = self.__get_header()
+        return requests.get(url, headers=headers).json()
 
     def json(self, dictionary, id):
-        headers = {'Accept': 'application/json'} 
+        headers = self.__get_header()
+        headers['Accept'] = 'application/json'
         r = requests.get(f"{self.endpoint}json/{dictionary}/{id}",
                 headers=headers)
         return r.json()

--- a/src/main.py
+++ b/src/main.py
@@ -43,6 +43,8 @@ if __name__ == "__main__":
                            help="List of metrics to evaluate")
     argparser.add_argument("--max-entries",
                            help="Maximum number of entries to evaluate")
+    argparser.add_argument("--api-key",
+                            help="The API KEY to use")
 
     args = argparser.parse_args()
     if args.max_entries:
@@ -57,7 +59,7 @@ if __name__ == "__main__":
         endpoint = args.e if args.e else "http://localhost:8000/"
         report = {"endpoint": endpoint}
 
-        api_instance = ApiClient(endpoint)
+        api_instance = ApiClient(endpoint, args.api_key)
         try:
             dictionary_list = list_dictionaries(api_instance)
             report["available"] = True


### PR DESCRIPTION
Allows API keys to be specified on the command line. You can test it as follows, by replace `XXX` with the API key from Adam

```
python src/main.py -e http://lexonomy.elex.is --api-key XXX --max-entries=1000 -d i8ft6w8h
Evaluating 1 dictionaries
Evaluating i8ft6w8h.
{"endpoint": "http://lexonomy.elex.is", "available": true, "dictionaries": {"i8ft6w8h": {"metadataErrors": ["Source language not specified", "Target language(s) not specified", "Genre(s) not specified", "License not specified", "Title not specified", "Publisher not specified"], "entryErrors": ["Language value was invalid: None", "Language value was invalid: None", "Language value was invalid: None"]}}}
```
